### PR TITLE
Eventstore pass stream prefix

### DIFF
--- a/src/EventSerializers.ts
+++ b/src/EventSerializers.ts
@@ -1,7 +1,7 @@
 import { LetterGuessedEvent } from './Hangman/Domain/Events/LetterGuessed.event';
 import { NewGameStartedEvent } from './Hangman/Domain/Events/NewGameStarted.event';
 
-export const EventStoreInstanciators = {
+export const EventSerializers = {
   NewGameStartedEvent: ({
     id,
     playerId,

--- a/src/Hangman/Domain/Events/LetterGuessed.event.ts
+++ b/src/Hangman/Domain/Events/LetterGuessed.event.ts
@@ -1,7 +1,6 @@
-import { StorableEvent } from '@berniemac/event-sourcing-nestjs';
+import { StorableEvent } from '../../Infrastructure/EventStore/Interfaces';
 
 export class LetterGuessedEvent extends StorableEvent {
-  eventAggregate = 'game';
   eventVersion = 1;
 
   dateModified: Date;

--- a/src/Hangman/Domain/Events/NewGameStarted.event.ts
+++ b/src/Hangman/Domain/Events/NewGameStarted.event.ts
@@ -1,7 +1,6 @@
-import { StorableEvent } from '@berniemac/event-sourcing-nestjs';
+import { StorableEvent } from '../../Infrastructure/EventStore/Interfaces';
 
 export class NewGameStartedEvent extends StorableEvent {
-  eventAggregate = 'game';
   eventVersion = 1;
 
   constructor(
@@ -10,7 +9,7 @@ export class NewGameStartedEvent extends StorableEvent {
     public readonly wordToGuess: string,
     public readonly maxGuesses: number,
     public readonly dateCreated: Date,
-    public readonly dateModified: Date, // public readonly lettersGuessed: string[],
+    public readonly dateModified: Date,
   ) {
     super();
   }

--- a/src/Hangman/Domain/Repositories/GamesRepository.ts
+++ b/src/Hangman/Domain/Repositories/GamesRepository.ts
@@ -3,10 +3,14 @@ import { Injectable, Logger } from '@nestjs/common';
 import { GameDto } from '../../Infrastructure/Dto/Game.dto';
 import { Game } from '../AggregateRoot/Game.aggregate';
 import { EventStore } from '../../Infrastructure/EventStore/EventStore';
+import { StoreEventBus } from '../../Infrastructure/EventStore/EventBus';
 
 @Injectable()
 export class GamesRepository {
-  constructor(private readonly eventStore: EventStore) {} //
+  constructor(
+    private readonly eventStore: EventStore,
+    private readonly eventBus: StoreEventBus,
+  ) {} //
   private logger = new Logger(GamesRepository.name);
 
   private observer = new PerformanceObserver((items) =>
@@ -15,7 +19,10 @@ export class GamesRepository {
 
   async findOneById(aggregateId: string): Promise<Game> {
     const game = new Game(aggregateId);
-    const { events } = await this.eventStore.getEvents('game', aggregateId);
+    const { events } = await this.eventStore.getEvents(
+      this.eventBus.streamPrefix,
+      aggregateId,
+    );
     game.loadFromHistory(events);
     return game;
   }

--- a/src/Hangman/Infrastructure/EventStore/EventBus.ts
+++ b/src/Hangman/Infrastructure/EventStore/EventBus.ts
@@ -42,8 +42,7 @@ export class StoreEventBus extends EventBus implements IEventBus {
     ) {
       throw new Error('Events must implement StorableEvent interface');
     }
-    console.log('storing');
-    this.eventStore.storeEvent(storableEvent, this.streamPrefix);
+    this.eventStore.storeEvent(storableEvent);
   }
 
   publishAll(events: IEvent[]): void {

--- a/src/Hangman/Infrastructure/EventStore/EventBus.ts
+++ b/src/Hangman/Infrastructure/EventStore/EventBus.ts
@@ -10,12 +10,12 @@ import { ViewEventBus } from './Views';
 @Injectable()
 export class StoreEventBus extends EventBus implements IEventBus {
   constructor(
-    // streamPrefix: string,
     commandBus: CommandBus,
     moduleRef: ModuleRef,
     private readonly eventStore: EventStore,
     private readonly event$: EventBus,
     private readonly viewEventsBus: ViewEventBus,
+    private streamPrefix: string,
   ) {
     super(commandBus, moduleRef);
   }
@@ -27,7 +27,7 @@ export class StoreEventBus extends EventBus implements IEventBus {
     );
     subscriber.bridgeEventsTo(this.event$.subject$);
     subscriber.getAll(); // from checkpoint xxx comes later
-    subscriber.subscribe('game');
+    subscriber.subscribe(this.streamPrefix);
   }
 
   publish<T extends IEvent>(event: T): void {

--- a/src/Hangman/Infrastructure/EventStore/EventBus.ts
+++ b/src/Hangman/Infrastructure/EventStore/EventBus.ts
@@ -9,24 +9,27 @@ import { ViewEventBus } from './Views';
 
 @Injectable()
 export class StoreEventBus extends EventBus implements IEventBus {
+  public streamPrefix: string;
+
   constructor(
     commandBus: CommandBus,
     moduleRef: ModuleRef,
     private readonly eventStore: EventStore,
     private readonly event$: EventBus,
     private readonly viewEventsBus: ViewEventBus,
-    private streamPrefix: string,
+    streamPrefix: string,
   ) {
     super(commandBus, moduleRef);
+    this.streamPrefix = streamPrefix;
   }
 
-  onModuleInit() {
+  async onModuleInit() {
     const subscriber = new EventStoreEventSubscriber(
       this.eventStore,
       this.viewEventsBus,
     );
     subscriber.bridgeEventsTo(this.event$.subject$);
-    subscriber.getAll(); // from checkpoint xxx comes later
+    await subscriber.getAll(); // from checkpoint xxx comes later
     subscriber.subscribe(this.streamPrefix);
   }
 

--- a/src/Hangman/Infrastructure/EventStore/EventBus.ts
+++ b/src/Hangman/Infrastructure/EventStore/EventBus.ts
@@ -42,8 +42,8 @@ export class StoreEventBus extends EventBus implements IEventBus {
     ) {
       throw new Error('Events must implement StorableEvent interface');
     }
-
-    this.eventStore.storeEvent(storableEvent);
+    console.log('storing');
+    this.eventStore.storeEvent(storableEvent, this.streamPrefix);
   }
 
   publishAll(events: IEvent[]): void {

--- a/src/Hangman/Infrastructure/EventStore/EventBus.ts
+++ b/src/Hangman/Infrastructure/EventStore/EventBus.ts
@@ -37,16 +37,14 @@ export class StoreEventBus extends EventBus implements IEventBus {
     const storableEvent = (event as any) as StorableEvent;
     if (
       storableEvent.id === undefined ||
-      storableEvent.eventAggregate === undefined ||
       storableEvent.eventVersion === undefined
     ) {
       throw new Error('Events must implement StorableEvent interface');
     }
-    this.eventStore.storeEvent(storableEvent);
+    this.eventStore.storeEvent(storableEvent, this.streamPrefix);
   }
 
   publishAll(events: IEvent[]): void {
-    // what does this do?
     (events || []).forEach((event) => this.publish(event));
   }
 }

--- a/src/Hangman/Infrastructure/EventStore/EventStore.ts
+++ b/src/Hangman/Infrastructure/EventStore/EventStore.ts
@@ -131,7 +131,8 @@ export class EventStore {
     this.streamPrefix = streamPrefix;
   }
 
-  async getAll(viewEventsBus: ViewEventBus) {
+  async getAll(viewEventsBus: ViewEventBus): Promise<void> {
+    this.logger.log('Replaying all events to build projection');
     // maybe not readAll
     const events = this.eventstore.readAll();
 
@@ -163,6 +164,7 @@ export class EventStore {
         bridge.next(parsedEvent);
       }
     });
+    this.logger.log(`Subscribed to all streams with prefix '${streamPrefix}-'`);
   }
 
   // Monkey patch to obtain event 'instances' from db

--- a/src/Hangman/Infrastructure/EventStore/EventStore.ts
+++ b/src/Hangman/Infrastructure/EventStore/EventStore.ts
@@ -82,10 +82,7 @@ export class EventStore {
   //   });
   // }
 
-  public async storeEvent<T extends IEvent>(
-    event: T,
-    prefix: string,
-  ): Promise<void> {
+  public async storeEvent<T extends IEvent>(event: T): Promise<void> {
     return new Promise<void>(async (resolve, reject) => {
       if (!this.eventStoreLaunched) {
         reject('Event Store not launched!');
@@ -98,7 +95,10 @@ export class EventStore {
 
       try {
         const events = this.eventstore.readStream(
-          this.getAggregateId(prefix, eventDeserialized.id),
+          this.getAggregateId(
+            eventDeserialized.eventAggregate,
+            eventDeserialized.id,
+          ),
           {
             fromRevision: START,
             direction: FORWARDS,

--- a/src/Hangman/Infrastructure/EventStore/EventStore.ts
+++ b/src/Hangman/Infrastructure/EventStore/EventStore.ts
@@ -82,7 +82,10 @@ export class EventStore {
   //   });
   // }
 
-  public async storeEvent<T extends IEvent>(event: T): Promise<void> {
+  public async storeEvent<T extends IEvent>(
+    event: T,
+    prefix: string,
+  ): Promise<void> {
     return new Promise<void>(async (resolve, reject) => {
       if (!this.eventStoreLaunched) {
         reject('Event Store not launched!');
@@ -95,10 +98,7 @@ export class EventStore {
 
       try {
         const events = this.eventstore.readStream(
-          this.getAggregateId(
-            eventDeserialized.eventAggregate,
-            eventDeserialized.id,
-          ),
+          this.getAggregateId(prefix, eventDeserialized.id),
           {
             fromRevision: START,
             direction: FORWARDS,

--- a/src/Hangman/Infrastructure/EventStore/Interfaces/index.ts
+++ b/src/Hangman/Infrastructure/EventStore/Interfaces/index.ts
@@ -10,7 +10,6 @@ export interface IEventMeta {
 
 export abstract class StorableEvent implements IEvent {
   abstract id: string;
-  abstract eventAggregate: string;
   abstract eventVersion: number;
   eventName: string;
 

--- a/src/Hangman/Infrastructure/EventStore/Interfaces/index.ts
+++ b/src/Hangman/Infrastructure/EventStore/Interfaces/index.ts
@@ -4,6 +4,10 @@ export interface EventSourcingOptions {
   eventStoreUrl: string;
 }
 
+export interface EventSerializers {
+  [EventName: string]: (options: unknown) => StorableEvent;
+}
+
 export interface IEventMeta {
   revision: number;
 }

--- a/src/Hangman/Infrastructure/EventStore/Subscriber.ts
+++ b/src/Hangman/Infrastructure/EventStore/Subscriber.ts
@@ -31,8 +31,8 @@ export class EventStoreEventSubscriber implements IMessageSource {
     this.stream = prefix;
   }
 
-  getAll() {
-    this.eventStore.getAll(this.viewEventsBus);
+  async getAll() {
+    await this.eventStore.getAll(this.viewEventsBus);
   }
 
   subscribe(streamPrefix) {

--- a/src/Hangman/Infrastructure/EventStore/Subscriber.ts
+++ b/src/Hangman/Infrastructure/EventStore/Subscriber.ts
@@ -10,26 +10,22 @@ export class EventStoreEventSubscriber implements IMessageSource {
   private bridge: Subject<any>;
   public isConnected = false;
   public hasBridge = false;
-  public stream = '';
 
   private logger = new Logger(EventStoreEventSubscriber.name);
 
   constructor(
     private readonly eventStore: EventStore,
     private readonly viewEventsBus: ViewEventBus,
+    private readonly streamPrefix: string,
   ) {}
 
-  setStreamPrefix(prefix: string) {
-    this.stream = prefix;
-  }
-
   async getAll() {
-    await this.eventStore.getAll(this.viewEventsBus);
+    await this.eventStore.getAll(this.viewEventsBus, this.streamPrefix);
   }
 
-  subscribe(streamPrefix) {
+  subscribe() {
     if (this.bridge) {
-      this.eventStore.subscribe(streamPrefix, this.bridge);
+      this.eventStore.subscribe(this.streamPrefix, this.bridge);
     }
   }
 

--- a/src/Hangman/Infrastructure/EventStore/Subscriber.ts
+++ b/src/Hangman/Infrastructure/EventStore/Subscriber.ts
@@ -1,16 +1,8 @@
 import { IEvent, IMessageSource } from '@nestjs/cqrs';
 import { Subject } from 'rxjs';
-import {
-  EventStoreDBClient,
-  START,
-  streamNameFilter,
-} from '@eventstore/db-client';
-import { EventStoreInstanciators } from '../../../event-store';
+import { EventStoreDBClient } from '@eventstore/db-client';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventStore } from './EventStore';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Game as GameProjection } from '../../ReadModels/game.entity';
-import { Repository } from 'typeorm';
 import { ViewEventBus } from './Views';
 
 export class EventStoreEventSubscriber implements IMessageSource {

--- a/src/modules/eventstore.module.ts
+++ b/src/modules/eventstore.module.ts
@@ -1,8 +1,10 @@
 import { Module, DynamicModule, Logger } from '@nestjs/common';
-import { EventSourcingOptions } from '../Hangman/Infrastructure/EventStore/Interfaces';
+import {
+  EventSerializers,
+  EventSourcingOptions,
+} from '../Hangman/Infrastructure/EventStore/Interfaces';
 import { CommandBus, CqrsModule, EventBus } from '@nestjs/cqrs';
 import { EventStore } from '../Hangman/Infrastructure/EventStore/EventStore';
-import { createEventSourcingProviders } from '../Hangman/Infrastructure/EventStore/Providers';
 import { EventStoreEventSubscriber } from '../Hangman/Infrastructure/EventStore/Subscriber';
 import {
   ViewEventBus,
@@ -36,6 +38,7 @@ export class EventSourcingModule {
 
   static async forFeature(options: {
     streamPrefix: string;
+    eventSerializers: EventSerializers;
   }): Promise<DynamicModule> {
     return {
       module: EventSourcingModule,
@@ -59,6 +62,7 @@ export class EventSourcingModule {
               event$,
               viewEventsBus,
               options.streamPrefix,
+              options.eventSerializers,
             );
           },
           inject: [CommandBus, ModuleRef, EventStore, EventBus, ViewEventBus],

--- a/src/modules/game.module.ts
+++ b/src/modules/game.module.ts
@@ -11,11 +11,15 @@ import ProjectionUpdaters from '../Hangman/Domain/Updaters';
 import { GamesResolver } from '../resolvers/game.resolver';
 import { Game as GameProjection } from '../Hangman/ReadModels/game.entity';
 import { EventSourcingModule } from './eventstore.module';
+import { EventSerializers } from '../EventSerializers';
 
 @Module({
   imports: [
     CqrsModule,
-    EventSourcingModule.forFeature({ streamPrefix: 'game' }),
+    EventSourcingModule.forFeature({
+      streamPrefix: 'game',
+      eventSerializers: EventSerializers,
+    }),
     TypeOrmModule.forFeature([GameProjection]),
   ],
   exports: [CqrsModule],


### PR DESCRIPTION
in src/Hangman/Infrastructure/EventStore/EventStore.ts `storeEvent` now the `event.eventAggregate` is used to define the event-id. This means in the events we need `eventAggregate = 'game'`.
So this is another place in the code where we have to write the string 'game'. 
We could use the `streamPrefix` passed in the module's `forFeature` method. Then every event would use this `streamPrefix` for sure and there would only be 1 place where we write this. 

Is it desireable that every event has 
```
  eventAggregate = 'game';
  eventVersion = 1;
```
?